### PR TITLE
FLUID-5809: Fixed hiding of Topics skip link when sidebar hidden

### DIFF
--- a/src/documents/css/docs-template.css.styl
+++ b/src/documents/css/docs-template.css.styl
@@ -238,7 +238,6 @@ html body {
     color: link-color;
     text-decoration: underline;
     transition: backgroundColor 0.15s, background 0.15s, color 0.15s;
-    display:inline-block;
 }
 
 .docs-template a:hover {


### PR DESCRIPTION
Removed link styling that was preventing the Topics skip link from being hidden when the sidebar is collapsed.

@acheetham Can you take a look at this? I will issue a pull request to the ILDH so it gets this change as well.