### PR TITLE
FLUID-5941: Fixed sidebar not appearing in IE11.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-template",
   "description": "Templates, styles, and sample content for a documentation website.",
-  "version": "0.0.1-SNAPSHOT",
+  "version": "0.0.2-SNAPSHOT",
   "author": "Fluid Project",
   "bugs": "http://issues.fluidproject.org/browse/FLUID",
   "homepage": "http://www.fluidproject.org/",

--- a/src/documents/css/docs-template.css.styl
+++ b/src/documents/css/docs-template.css.styl
@@ -607,7 +607,7 @@ html body {
 }
 
 .docs-core-sidebar-expanded .docs-template-topics {
-    display: initial; // restore tabbability of topics
+    display: block; // restore tabbability of topics
 }
 
 .docs-template-topics-hideShow {


### PR DESCRIPTION
Changed the display initial to display block for the expanding sidebar. This fixes a problem with the sidebar not appearing in IE 11.
